### PR TITLE
Fix Bandit warning in tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest flake8 black bandit
+
+      - name: Lint with flake8
+        run: flake8 .
+
+      - name: Check formatting with black
+        run: black --check .
+
+      - name: Security analysis with bandit
+        run: bandit -r . --exclude venv
+
+      - name: Run tests
+        run: pytest
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false # change to true to push image to registry
+          tags: ${{ secrets.DOCKER_USERNAME }}/fastapi-ci-cd-demo:latest

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Siga os passos abaixo para configurar e executar o projeto em sua máquina local
 
     ```bash
     git clone <URL_DO_SEU_REPOSITORIO>
-    cd ci-cd-fastapi-project
+    cd Pipeline-CI-CD-com-GitHub-Actions-e-FastAPI
     ```
 
 2.  **Crie e ative o ambiente virtual:**
@@ -85,12 +85,17 @@ O arquivo `.github/workflows/main.yml` define o pipeline CI/CD que será executa
 -   **Execução de Testes**: Executa os testes unitários com `pytest`.
 -   **Build e Push da Imagem Docker**: Constrói a imagem Docker da aplicação. (Atualmente configurado para não fazer push, mas pode ser habilitado para um registro de contêiner como Docker Hub ou GitHub Container Registry).
 
+### Configurando Secrets do GitHub
+
+Para permitir o envio da imagem para um registro de contêiner, crie um secret `DOCKER_USERNAME` no repositório com o seu usuário do Docker Hub (ou outro registro). Em seguida, altere `push: false` para `push: true` no arquivo `.github/workflows/main.yml` e adicione o secret `DOCKER_PASSWORD` contendo a senha ou token do registro escolhido.
+
 ## Próximos Passos
 
 -   Configurar o push da imagem Docker para um registro de contêiner.
 -   Implementar a implantação contínua (CD) para um ambiente de nuvem (ex: AWS, Azure, GCP) usando Terraform.
 -   Adicionar mais testes (integração, ponta a ponta).
 -   Monitoramento e logging.
+-   Aprimorar a análise de código estática com ferramentas mais robustas ou serviços integrados.
 
 
 

--- a/test_main.py
+++ b/test_main.py
@@ -6,11 +6,11 @@ client = TestClient(app)
 
 def test_read_root():
     response = client.get("/")
-    assert response.status_code == 200
-    assert response.json() == {"message": "Hello, CI/CD with FastAPI!"}
+    assert response.status_code == 200  # nosec B101
+    assert response.json() == {"message": "Hello, CI/CD with FastAPI!"}  # nosec B101
 
 
 def test_health_check():
     response = client.get("/health")
-    assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
+    assert response.status_code == 200  # nosec B101
+    assert response.json() == {"status": "ok"}  # nosec B101


### PR DESCRIPTION
## Summary
- silence bandit false positives in unit tests

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies requirement due to network access)*
- `flake8 .` *(fails: command not found)*
- `black --check .`
- `bandit -r . --exclude venv` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_686af55fc0588327ab0ee94ba850c2f5